### PR TITLE
Fix allowParams case sensitivity

### DIFF
--- a/dist/latest/latest.dev.js
+++ b/dist/latest/latest.dev.js
@@ -1,4 +1,4 @@
-/* Simple Analytics - Privacy-first analytics (docs.simpleanalytics.com/script; 2025-06-24; 80f5; v12) */
+/* Simple Analytics - Privacy-first analytics (docs.simpleanalytics.com/script; 2025-07-29; 9107; v12) */
 /* eslint-env browser */
 
 (function (
@@ -244,7 +244,7 @@
 
             // The prefix "utm_" is optional with "strictUtm" disabled
             // "ref" is only collected when "strictUtm" is disabled
-            return new RegExp(regex).test(keyValue);
+            return new RegExp(regex, "i").test(keyValue);
           })
           .join("&") || undefinedVar
       );

--- a/src/default.js
+++ b/src/default.js
@@ -271,7 +271,7 @@
 
             // The prefix "utm_" is optional with "strictUtm" disabled
             // "ref" is only collected when "strictUtm" is disabled
-            return new RegExp(regex).test(keyValue);
+            return new RegExp(regex, "i").test(keyValue);
           })
           .join("&") || undefinedVar
       );

--- a/test/unit/pageview-query.test.js
+++ b/test/unit/pageview-query.test.js
@@ -19,4 +19,22 @@ describe("pageview query", function () {
       done();
     }, 10);
   });
+
+  it("matches allowed params case insensitively", function (done) {
+    const dom = createDOM({
+      settings: { autoCollect: false, allowParams: "foo" },
+    });
+
+    dom.window.sa_pageview("/manual?FOO=bar");
+
+    setTimeout(() => {
+      const req = dom.sent.find(
+        (r) => r.type === "image" && /path=%2Fmanual/.test(r.url)
+      );
+      expect(req, "pageview request").to.exist;
+      const url = new URL(req.url);
+      expect(url.searchParams.get("query")).to.equal("FOO=bar");
+      done();
+    }, 10);
+  });
 });


### PR DESCRIPTION
## Summary
- make the allowParams regex case-insensitive
- add unit test covering case-insensitive allowParams
- compile latest.dev.js

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6888ca4bb50083238243e4b66ba7d4cb