### PR TITLE
Fix nested chiren links in a tags

### DIFF
--- a/src/auto-events.js
+++ b/src/auto-events.js
@@ -190,8 +190,8 @@
 
       link.setAttribute("onclick", onClickAttribute);
     } else {
-      link.addEventListener("click", function (element) {
-        saAutomatedLink(element.target, collect);
+      link.addEventListener("click", function () {
+        saAutomatedLink(this, collect);
       });
     }
   }


### PR DESCRIPTION
## Summary

Closes #90

Fixes auto-events not firing when a link (`<a>`) wraps nested elements such as an inline SVG. The delegated click handler previously read `event.target`, which resolves to the innermost clicked element (e.g. the `<svg>`/`<path>`) rather than the anchor, so `saAutomatedLink` received an element without link properties (`href`, `pathname`, `hostname`) and no event was collected. The handler now passes `this`, the anchor the listener is bound to, matching the inline `onclick` path that already uses `this`.

<!-- simpleanalytics:changes-start -->
Changes:
- fix nested svg bug
<!-- simpleanalytics:changes-end -->

## Security implications

Has security impact - described as: changes analytics data-collection behavior in the customer-facing tracking script. It is a client-side correctness fix that restores link-click event collection for anchors wrapping nested elements; it does not expose new data, change permissions, or alter data handling beyond restoring the intended tracking.

## Testing

Manual testing by the author. Claude review: no automated validation run (node/build commands were not permitted in this environment); change is a one-line, isolated correctness fix in `src/auto-events.js`, verified by inspection.

## Checklist

- [x] Linked to an issue
- [x] Tested
- [x] Asked for a review
